### PR TITLE
Avoiding multiple matches

### DIFF
--- a/openstack-clients/windows/Source_OpenRC.ps1
+++ b/openstack-clients/windows/Source_OpenRC.ps1
@@ -38,12 +38,12 @@ Else {
     #
     # *NOTE*: Using the 2.0 *auth api* does not mean that compute api is 2.0.  We
     # will use the 1.1 *compute api*
-    $os_project_name = Select-String -Path $openrc -Pattern 'OS_PROJECT_NAME'
+    $os_project_name = Select-String -Path $openrc -Pattern 'export OS_PROJECT_NAME'
     If ($os_project_name) {
         $env:OS_PROJECT_NAME = ([string]($os_project_name)).Split("=")[1].Replace("`"","")
     }
     Else {
-        Write $error
+        Write $rcerror
         Exit
     }
 
@@ -54,42 +54,47 @@ Else {
     #    $env:OS_TENANT_ID = ([string]($os_tenant_id)).Split("=")[1].Replace("`"","")
     #}
     #Else {
-    #    Write $error
+    #    Write $rcerror
     #    Exit
     #}
 
-    $os_auth_url = Select-String -Path $openrc -Pattern 'OS_AUTH_URL'
+    $os_auth_url = Select-String -Path $openrc -Pattern 'export OS_AUTH_URL'
     If ($os_auth_url) {
         $env:OS_AUTH_URL = ([string]($os_auth_url)).Split("=")[1].Replace("`"","")
     }
     Else {
-        Write $error
+        Write $rcerror
         Exit
     }
 
     # In addition to the owning entity (tenant), openstack stores the entity
     # performing the action as the **user**.
-    $os_username = Select-String -Path $openrc -Pattern 'OS_USERNAME'
+    $os_username = Select-String -Path $openrc -Pattern 'export OS_USERNAME'
     If ($os_username) {
         $env:OS_USERNAME = ([string]($os_username)).Split("=")[1].Replace("`"","")
     }
     Else {
-        Write $error
+        Write $rcerror
         Exit
     }
 
     # With Keystone you pass the keystone password.
-    $password = Select-String -Path $openrc -Pattern 'OS_PASSWORD'
-    $env:OS_PASSWORD = ([string]($password)).Split("=")[1].Replace("`"","")
-	
+    $password = Select-String -Path $openrc -Pattern 'export OS_PASSWORD'
+    $foundpassword = ([string]($password)).Split("=")[1].Replace("`"","")
+    If ($foundpassword -match '\$OS_PASSWORD_INPUT') {
+    	Write-Host 'No Password found.  Set with $env:OS_PASSWORD=YourPassword'
+    } 
+    Else {
+    	$env:OS_PASSWORD = $foundpassword
+    }
 	###Adding variable OS_REGION_NAME and OS_IDENTITY_API_VERSION
 	
-	    $os_region_name = Select-String -Path $openrc -Pattern 'OS_REGION_NAME'
+    $os_region_name = Select-String -Path $openrc -Pattern 'export OS_REGION_NAME'
     If ($os_region_name) {
         $env:OS_REGION_NAME = ([string]($os_region_name)).Split("=")[1].Replace("`"","")
     }
     Else {
-        Write $error
+        Write $rcerror
         Exit
     }
 	
@@ -98,7 +103,7 @@ Else {
         $env:OS_IDENTITY_API_VERSION = ([string]($os_identity_api_version)).Split("=")[1].Replace("`"","")
     }
     Else {
-        Write $error
+        Write $rcerror
         Exit
     }
 }

--- a/openstack-clients/windows/Source_OpenRC.ps1
+++ b/openstack-clients/windows/Source_OpenRC.ps1
@@ -14,22 +14,22 @@
 #>
 
 If ($args.count -lt 1) {
-    Write "Please provide an OpenRC file as argument."
+    Write-Host "Please provide an OpenRC file as argument."
     Exit
 }
 
 ElseIf ($args.count -gt 1) {
-    Write "Please provide a single OpenRC file as argument."
+    Write-Host "Please provide a single OpenRC file as argument."
     Exit
 }
 
 ElseIf (-Not (Test-Path $args[0])) {
-    Write "The OpenRC file you specified doesn't exist!"
+    Write-Host "The OpenRC file you specified doesn't exist!"
     Exit
 }
 Else {
     $openrc = $args[0]
-    $error = "The file you specified doesn't seem to be a valid OpenRC file"
+    $rcerror = "The file you specified doesn't seem to be a valid OpenRC file"
 
     # With the addition of Keystone, to use an openstack cloud you should
     # authenticate against keystone, which returns a **Token** and **Service
@@ -43,7 +43,7 @@ Else {
         $env:OS_PROJECT_NAME = ([string]($os_project_name)).Split("=")[1].Replace("`"","")
     }
     Else {
-        Write $rcerror
+        Write-Host $rcerror
         Exit
     }
 
@@ -54,7 +54,7 @@ Else {
     #    $env:OS_TENANT_ID = ([string]($os_tenant_id)).Split("=")[1].Replace("`"","")
     #}
     #Else {
-    #    Write $rcerror
+    #    Write-Host $rcerror
     #    Exit
     #}
 
@@ -63,7 +63,7 @@ Else {
         $env:OS_AUTH_URL = ([string]($os_auth_url)).Split("=")[1].Replace("`"","")
     }
     Else {
-        Write $rcerror
+        Write-Host $rcerror
         Exit
     }
 
@@ -74,7 +74,7 @@ Else {
         $env:OS_USERNAME = ([string]($os_username)).Split("=")[1].Replace("`"","")
     }
     Else {
-        Write $rcerror
+        Write-Host $rcerror
         Exit
     }
 
@@ -82,7 +82,7 @@ Else {
     $password = Select-String -Path $openrc -Pattern 'export OS_PASSWORD'
     $foundpassword = ([string]($password)).Split("=")[1].Replace("`"","")
     If ($foundpassword -match '\$OS_PASSWORD_INPUT') {
-    	Write-Host 'No Password found.  Set with $env:OS_PASSWORD=YourPassword'
+    	Write-Host-Host 'No Password found.  Set with $env:OS_PASSWORD=YourPassword'
     } 
     Else {
     	$env:OS_PASSWORD = $foundpassword
@@ -94,7 +94,7 @@ Else {
         $env:OS_REGION_NAME = ([string]($os_region_name)).Split("=")[1].Replace("`"","")
     }
     Else {
-        Write $rcerror
+        Write-Host $rcerror
         Exit
     }
 	
@@ -103,7 +103,7 @@ Else {
         $env:OS_IDENTITY_API_VERSION = ([string]($os_identity_api_version)).Split("=")[1].Replace("`"","")
     }
     Else {
-        Write $rcerror
+        Write-Host $rcerror
         Exit
     }
 }


### PR DESCRIPTION
Changing the search approach to find the precise line instead of multiple potential matches.  

Changing error to rcerror to allow for powershell debugging.