### PR TITLE
Update the AWS IAM policy json for PMK

### DIFF
--- a/pmk/aws-policy.json
+++ b/pmk/aws-policy.json
@@ -72,7 +72,9 @@
                 "iam:GetRole",
                 "iam:GetRolePolicy",
                 "iam:GetUser",
+                "iam:ListAttachedRolePolicies",
                 "iam:ListInstanceProfilesForRole",
+                "iam:ListRolePolicies",
                 "iam:PassRole",
                 "iam:PutRolePolicy",
                 "iam:RemoveRoleFromInstanceProfile"


### PR DESCRIPTION
Terraform AWS provider resource field has Terraform perform additional
AWS API calls which require additional permissions.

Related Issue:
https://platform9.atlassian.net/browse/PMK-1408