### PR TITLE
Added ModifyNetworkInterfaceAttribute permissions to Omni

### DIFF
--- a/omni/aws-policy.json
+++ b/omni/aws-policy.json
@@ -77,7 +77,8 @@
                 "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeAddresses",
                 "ec2:GetConsoleOutput",
-                "ec2:GetPasswordData"
+                "ec2:GetPasswordData",
+                "ec2:ModifyNetworkInterfaceAttribute"
             ],
             "Effect": "Allow",
             "Resource": "*"


### PR DESCRIPTION
- To update instance's security group (ports) in AWS when they are updated in
OpenStack, we need to call ModifyNetworkInterfaceAttribute API of boto3.