### PR TITLE
add EKS R/O permissions to PMK IAM template

### DIFF
--- a/pmk/aws-policy.json
+++ b/pmk/aws-policy.json
@@ -65,7 +65,7 @@
                 "iam:AddRoleToInstanceProfile",
                 "iam:CreateInstanceProfile",
                 "iam:CreateRole",
-		"iam:CreateServiceLinkedRole",
+                "iam:CreateServiceLinkedRole",
                 "iam:DeleteInstanceProfile",
                 "iam:DeleteRole",
                 "iam:DeleteRolePolicy",
@@ -98,7 +98,8 @@
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeTags",
                 "elasticloadbalancing:ModifyLoadBalancerAttributes",
-                "elasticloadbalancing:RemoveTags"
+                "elasticloadbalancing:RemoveTags",
+                "elasticloadbalancing:DescribeInstanceHealth"
             ],
             "Resource": [
                 "*"
@@ -135,8 +136,30 @@
                 "autoscaling:EnableMetricsCollection",
                 "autoscaling:UpdateAutoScalingGroup",
                 "autoscaling:SuspendProcesses",
-                "autoscaling:ResumeProcesses",
-                "elasticloadbalancing:DescribeInstanceHealth"
+                "autoscaling:ResumeProcesses"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "eks:DescribeFargateProfile",
+                "eks:ListTagsForResource",
+                "eks:DescribeAddon",
+                "eks:DescribeNodegroup",
+                "eks:ListNodegroups",
+                "eks:DescribeIdentityProviderConfig",
+                "eks:AccessKubernetesApi",
+                "eks:DescribeCluster",
+                "eks:ListClusters",
+                "eks:ListAddons",
+                "eks:ListUpdates",
+                "eks:DescribeAddonVersions",
+                "eks:ListIdentityProviderConfigs",
+                "eks:ListFargateProfiles",
+                "eks:DescribeUpdate"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
Add read-only EKS permissions to the PMK cloud provider template to enable cluster imports. R/O EKS permission is mentioned in the prereq doc, but not in this policy example which it links to.

https://platform9.com/docs/kubernetes/aws-prerequisites

This permission list could be 

\+ a whitespace fix, and moving that one stray ELB permission from the ASG block to its true home.