### PR TITLE
PMK-4813 Add CNI policy for control-plane.cluster-api role

### DIFF
--- a/pmk/aws-capi-cloudformation.template
+++ b/pmk/aws-capi-cloudformation.template
@@ -386,6 +386,8 @@ Resources:
             Service:
             - ec2.amazonaws.com
         Version: 2012-10-17
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
       RoleName: control-plane.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role
   AWSIAMRoleControllers:


### PR DESCRIPTION
https://platform9.atlassian.net/browse/PMK-4813

CNI Policy was missing in role `control-plane.cluster-api-provider-aws.sigs.k8s.io` While the rest of the yaml was generated, this change was done manually, need to test it before merging this PR.

Note: Importing this yaml changes roles globally for everyone.