### PR TITLE
[PMK-5016] Add Permissions for EKS AssumeRole

### DIFF
--- a/pmk/aws-capi-cloudformation.template
+++ b/pmk/aws-capi-cloudformation.template
@@ -401,6 +401,16 @@ Resources:
             Service:
             - ec2.amazonaws.com
         Version: 2012-10-17
+      Policies:
+      - PolicyDocument:
+          Statement:
+          - Action:
+            - iam:GetPolicy
+            Effect: Allow
+            Resource:
+            - '*'
+          Version: 2012-10-17
+        PolicyName: cluster-api-provider-aws-sigs-k8s-io
       RoleName: controllers.cluster-api-provider-aws.sigs.k8s.io
     Type: AWS::IAM::Role
   AWSIAMRoleEKSControlPlane:

--- a/pmk/bootstrap-config.yaml
+++ b/pmk/bootstrap-config.yaml
@@ -7,4 +7,11 @@ spec:
       disable: false # Set to false to enable creation of the default node role for managed machine pools
     fargate:
       disable: true # Set to false to enable creation of the default role for the fargate profiles
-
+  clusterAPIControllers: # GetPolicy permissions required for AWSManagedMachinePool
+    disabled: false
+    extraStatements:
+      - Action:
+          - "iam:GetPolicy"
+        Effect: "Allow"
+        Resource:
+          - "*"


### PR DESCRIPTION
Missing Permission for EKS awsmanagedmachinepool

Issue: [Missing AWS resource from the GetPolicy permissions during machine pool reconciliation · Issue #2385 · kubernetes-sigs/cluster-api-provider-aws](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2385)

```
1 controller.go:317] controller/awsmanagedmachinepool "msg"="Reconciler error" 
"error"="failed to reconcile machine pool for AWSManagedMachinePool default/neha-eks-1-pool-0: error ensuring policies are attached: 
[arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly]: 
error getting policy arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy: AccessDenied: User: arn:aws:sts::514845858982:assumed-role/p9-controllers.cluster-api-provider-aws.sigs.k8s.io/1665401465250141563 
is not authorized to perform: iam:GetPolicy on resource: policy arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy because no identity-based policy allows the 
iam:GetPolicy action\n\tstatus code: 403, 
request id: 4cf608de-66d4-4afe-8ad2-e72619323b8c" "name"="neha-eks-1-pool-0" "namespace"="default" 
"reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AWSManagedMachinePool"
```

Fix: Adding the `extraStatements` for EKS managed machine pools in `bootstrap-config.yaml`

```
extraStatements:
      - Action:
          - "iam:GetPolicy"
        Effect: "Allow"
        Resource:
          - "*"
```