### PR TITLE
[PMK-4958] Need Permission to list regions and route53 hostedZones

### DIFF
--- a/pmk/aws-capi-cloudformation.template
+++ b/pmk/aws-capi-cloudformation.template
@@ -406,6 +406,8 @@ Resources:
           Statement:
           - Action:
             - iam:GetPolicy
+            - ec2:DescribeRegions
+            - route53:ListHostedZones
             Effect: Allow
             Resource:
             - '*'

--- a/pmk/bootstrap-config.yaml
+++ b/pmk/bootstrap-config.yaml
@@ -12,6 +12,8 @@ spec:
     extraStatements:
       - Action:
           - "iam:GetPolicy"
+          - "ec2:DescribeRegions" # Permission required to fetch all the regions details
+          - "route53:ListHostedZones" # Permission required to fetch all the route53 hostedZones details
         Effect: "Allow"
         Resource:
           - "*"


### PR DESCRIPTION
INFO: https://platform9.atlassian.net/wiki/spaces/~929908310/pages/3222077521/Design+Static+APIs+for+AWS+EKS+in+PF9-CAPI

Error:
```
Error fetching hostedzones. operation error Route 53: ListHostedZones, https response error StatusCode: 403, RequestID: d2c71e29-6b96-404a-a80e-37dd1e8c80bc, api error AccessDenied: User: arn:aws:sts::514845858982:assumed-role/test-controllers.cluster-api-provider-aws.sigs.k8s.io/aws-go-sdk-1668066228602889364 is not authorized to perform: route53:ListHostedZones because no identity-based policy allows the route53:ListHostedZones action
```

```
error fetching regions. operation error EC2: DescribeRegions, https response error StatusCode: 403, RequestID: 18765909-3ca9-4952-9e1c-a76b10c50126, api error UnauthorizedOperation: You are not authorized to perform this operation.
```