### PR TITLE
added support for multiple nlbs

### DIFF
--- a/emp/nlb-scripts/nlb_rollback.sh
+++ b/emp/nlb-scripts/nlb_rollback.sh
@@ -39,7 +39,7 @@ uninstall_cert_manager() {
 }
 
 detach_iam_policy() {
-    policy_arn=$(aws iam list-policies --query "Policies[?PolicyName=='EMPAWSLoadBalancerControllerIAMPolicy'].Arn" --output text)
+    policy_arn=$(aws iam list-policies --query "Policies[?PolicyName=='"${cluster_name}_LBPolicy"'].Arn" --output text)
 
     if [ -n "$policy_arn" ]; then
         role_name=$(aws iam list-entities-for-policy --policy-arn "$policy_arn" --query "PolicyRoles[].RoleName" --output text)
@@ -66,7 +66,7 @@ delete_iam_service_account() {
 }
 
 delete_iam_policy() {
-    policy_arn=$(aws iam list-policies --query "Policies[?PolicyName=='EMPAWSLoadBalancerControllerIAMPolicy'].Arn" --output text)
+    policy_arn=$(aws iam list-policies --query "Policies[?PolicyName=='"${cluster_name}_LBPolicy"'].Arn" --output text)
 
     if [ -n "$policy_arn" ]; then
         aws iam delete-policy --policy-arn "$policy_arn"
@@ -96,7 +96,11 @@ fi
 read -p "Enter the EKS cluster name: " cluster_name
 read -p "Enter the AWS region: " region
 
-uninstall_aws_load_balancer_controller
+# Delete the AWSLoadBalancerController
+read -p "Do you want to delete the AWSLoadBalancerController? (y/n): " delete_awsLBController
+if [[ "$delete_awsLBController" =~ ^[Yy]$ ]]; then
+    uninstall_aws_load_balancer_controller
+fi
 
 # Delete the IngressClass and IngressClassParams (if installed)
 read -p "Do you want to delete the IngressClass and IngressClassParams? (y/n): " delete_ingress_class


### PR DESCRIPTION
Earlier the NLB name was hardcoded, so there could only be one NLB in an AWS profile. 
Now this NLB is configured to use cluster name as the object name to create NLB which enables the user to create multiple NLBs for multiple clusters.

Testing:
Created two NLBs in one account for two EKS clusters and both ran successfully. 