### PR TITLE
Add cost analyser missing s3 permission

### DIFF
--- a/emp/emp_iam_cftemplate.yml
+++ b/emp/emp_iam_cftemplate.yml
@@ -140,6 +140,7 @@ Resources:
           - autoscaling:DescribeAutoScalingInstances
           - autoscaling:SetDesiredCapacity
           - autoscaling:SetInstanceProtection
+          - s3:PutObject
           Resource: "*"
         - Effect: Allow
           Action:


### PR DESCRIPTION
https://platform9.atlassian.net/browse/EMP-1417

One of cost analyser required permission is missing from cloud formation template. 