### PR TITLE
Add missing permissions observed for EMP user

### DIFF
--- a/emp/aws_policy.json
+++ b/emp/aws_policy.json
@@ -5,6 +5,7 @@
             "Effect": "Allow",
             "Action": [
                 "autoscaling:AttachLoadBalancers",
+                "autoscaling:AttachInstances",
                 "autoscaling:CreateAutoScalingGroup",
                 "autoscaling:CreateLaunchConfiguration",
                 "autoscaling:CreateOrUpdateTags",
@@ -46,6 +47,7 @@
                 "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstances",
+                "ec2:DescribeInstanceAttribute",
                 "ec2:DescribeInternetGateways",
                 "ec2:DescribeKeyPairs",
                 "ec2:DescribeNatGateways",
@@ -131,11 +133,9 @@
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:SetInstanceProtection",
                 "ec2:DescribeInstanceTypes",
-                "ec2:DescribeSecurityGroup",
                 "ec2:DescribeSecurityGroupRules",
                 "ec2:ModifyInstanceMetadataOptions",
                 "ec2:ModifySecurityGroupRules",
-                "ec2:UpdateSecurityGroup",
                 "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
                 "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
                 "eks:CreateNodegroup",
@@ -155,7 +155,8 @@
                 "elasticfilesystem:ListTagsForResource",
                 "elasticfilesystem:TagResource",
                 "elasticfilesystem:UntagResource",
-                "elasticfilesystem:UpdateFileSystem"
+                "elasticfilesystem:UpdateFileSystem",
+                "s3:PutObject"
             ],
             "Resource": "*"
         },
@@ -220,6 +221,8 @@
                 "ec2:DetachVolume",
                 "ec2:ModifyInstanceAttribute",
                 "ec2:ModifyVolume",
+                "ec2:GetLaunchTemplateData",
+                "ec2:DescribeInstanceStatus",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancerPolicy",
                 "elasticloadbalancing:CreateTargetGroup",

--- a/emp/emp_iam_cftemplate.yml
+++ b/emp/emp_iam_cftemplate.yml
@@ -52,6 +52,7 @@ Resources:
           - ec2:DescribeAvailabilityZones
           - ec2:DescribeImages
           - ec2:DescribeInstances
+          - ec2:DescribeInstanceAttribute
           - ec2:DescribeInternetGateways
           - ec2:DescribeKeyPairs
           - ec2:DescribeNatGateways
@@ -105,6 +106,8 @@ Resources:
           - ec2:DetachVolume
           - ec2:ModifyInstanceAttribute
           - ec2:ModifyVolume
+          - ec2:GetLaunchTemplateData
+          - ec2:DescribeInstanceStatus
           - eks:AccessKubernetesApi
           - eks:DescribeAddon
           - eks:DescribeAddonVersions
@@ -122,6 +125,7 @@ Resources:
           - eks:ListUpdates
           - eks:CreateNodegroup
           - autoscaling:AttachLoadBalancers
+          - autoscaling:AttachInstances
           - autoscaling:CreateAutoScalingGroup
           - autoscaling:CreateLaunchConfiguration
           - autoscaling:CreateOrUpdateTags


### PR DESCRIPTION
Few of the permissions were missing and found during a SE demo setup creation. 

https://platform9.atlassian.net/browse/EMP-1443

`Testing:`
```mysql
➜  support-locker git:(private/anirudh/emp-1443) ✗ aws cloudformation deploy --stack-name "EMP-org-havjishjfhxdvrxr" --template-file emp/emp_iam_cftemplate.yml --capabilities CAPABILITY_NAMED_IAM --profile emp-dev --parameter-overrides IAMUserName=pf9-anirudh-test

Waiting for changeset to be created..
Waiting for stack create/update to complete
Successfully created/updated stack - EMP-org-havjishjfhxdvrxr
➜  support-locker git:(private/anirudh/emp-1443) ✗ 
```

`The policies and user got created successfully - AWS CloudFormation.`

![creation](https://github.com/platform9/support-locker/assets/77390180/48cff986-1e05-44f2-bc8b-9507ad8a4bf7)
