### PR TITLE
removing cert-manager as it is now handled as a part of EMP controller

### DIFF
--- a/emp/nlb-scripts/nlb_rollback.sh
+++ b/emp/nlb-scripts/nlb_rollback.sh
@@ -110,13 +110,6 @@ if [[ "$delete_ingress_class" =~ ^[Yy]$ ]]; then
     delete_ingress_class
 fi
 
-# Delete cert-manager (if installed)
-read -p "Do you want to uninstall cert-manager? (y/n): " uninstall_cert_manager
-
-if [[ "$uninstall_cert_manager" =~ ^[Yy]$ ]]; then
-    uninstall_cert_manager
-fi
-
 detach_iam_policy
 delete_iam_service_account
 delete_iam_policy


### PR DESCRIPTION
We are installing/configuring cert-manager as a part of emp-controller now, so there is no need to install it again via this script.
PR for cert-manager: https://github.com/platform9/emp-service/pull/485